### PR TITLE
Fix CompileGraph compiliing on CUDA device

### DIFF
--- a/constensor-core/src/cuda_backend/mod.rs
+++ b/constensor-core/src/cuda_backend/mod.rs
@@ -476,7 +476,7 @@ impl BackendDevice for CudaDevice {
     ) -> Result<CompiledGraph<S, T, D>> {
         // Build a dependency graph of tensor indices
         let mut dep_graph = DiGraphMap::<usize, ()>::new();
-        for idx in graph.len() {
+        for idx in 0..graph.len() {
             dep_graph.add_node(idx);
         }
 


### PR DESCRIPTION
It seems to a tiny typo, after fixing it it's running just fine on cuda.

Sorry to bother you because of such a small problem.